### PR TITLE
Update syn 2 -> 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,17 +32,17 @@ json = ["serde_json"]
 
 # Note: proc-macro2, serde, serde_json, and syn are public dependencies.
 [dependencies]
-proc-macro2 = { version = "1.0.60", default-features = false }
-serde = "1.0.113"
-serde_derive = "1.0.113"
-syn = { version = "2", default-features = false, features = ["full"] }
+proc-macro2 = { version = "1.0.107", default-features = false }
+serde = "1.0.229"
+serde_derive = "1.0.229"
+syn = { version = "3", default-features = false, features = ["full"] }
 
 serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 quote = "1"
 serde_json = "1"
-syn = { version = "2", default-features = false, features = ["parsing", "printing", "full", "extra-traits"] }
+syn = { version = "3", default-features = false, features = ["parsing", "printing", "full", "extra-traits"] }
 
 [lints]
 workspace = true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ syn-serde = "0.3"
 ```toml
 [dependencies]
 syn-serde = { version = "0.3", features = ["json"] }
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 ```
 
 ```rust
@@ -98,7 +98,7 @@ similar but not identical to [Syn]. All data structures provided by syn-serde
 can be converted to the data structures of [Syn] and [proc-macro2].
 
 The data structures of syn-serde 0.3 is compatible with the data structures of
-[Syn] 2.x.
+[Syn] 3.x.
 
 [Syn]: https://github.com/dtolnay/syn
 [proc-macro2]: https://github.com/alexcrichton/proc-macro2

--- a/examples/json2rust/Cargo.toml
+++ b/examples/json2rust/Cargo.toml
@@ -4,8 +4,8 @@ edition = "2021"
 
 [dependencies]
 syn-serde = { path = "../..", features = ["json"] }
-syn = { version = "2", features = ["full"] }
-prettyplease = "0.2"
+syn = { version = "3", features = ["full"] }
+prettyplease = "0.3"
 quote = "1"
 
 [lints]

--- a/examples/json2rust/main.json
+++ b/examples/json2rust/main.json
@@ -51,6 +51,7 @@
     },
     {
       "fn": {
+        "modifiers": {},
         "ident": "main",
         "inputs": [],
         "output": {

--- a/examples/rust2json/Cargo.toml
+++ b/examples/rust2json/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 
 [dependencies]
 syn-serde = { path = "../..", features = ["json"] }
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 
 [lints]
 workspace = true

--- a/examples/rust2json/main.json
+++ b/examples/rust2json/main.json
@@ -54,6 +54,7 @@
     },
     {
       "fn": {
+        "modifiers": {},
         "ident": "main",
         "inputs": [],
         "output": {

--- a/examples/rust2pickle/Cargo.toml
+++ b/examples/rust2pickle/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 
 [dependencies]
 syn-serde = { path = "../.." }
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 serde-pickle = "1"
 
 [lints]

--- a/examples/rust2pickle/main.json
+++ b/examples/rust2pickle/main.json
@@ -45,6 +45,7 @@
     },
     {
       "fn": {
+        "modifiers": {},
         "ident": "main",
         "inputs": [],
         "output": {

--- a/src/data.rs
+++ b/src/data.rs
@@ -43,14 +43,13 @@ ast_struct! {
         pub(crate) attrs: Vec<Attribute>,
         #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
         pub(crate) vis: Visibility,
-        #[serde(rename = "mut")]
-        #[serde(default, skip_serializing_if = "FieldMutability::is_none")]
-        pub(crate) mutability: FieldMutability,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub(crate) ident: Option<Ident>,
         // TODO: can remove?
         #[serde(default, skip_serializing_if = "not")]
         pub(crate) colon_token: bool,
         pub(crate) ty: Type,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub(crate) default: Option<Expr>,
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -9,9 +9,9 @@ pub use crate::{
         ExprArray, ExprAssign, ExprAsync, ExprAwait, ExprBinary, ExprBlock, ExprBreak, ExprCall,
         ExprCast, ExprClosure, ExprConst, ExprContinue, ExprField, ExprForLoop, ExprGroup, ExprIf,
         ExprIndex, ExprInfer, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprMatch, ExprMethodCall,
-        ExprParen, ExprPath, ExprRange, ExprReference, ExprRepeat, ExprReturn, ExprStruct, ExprTry,
-        ExprTryBlock, ExprTuple, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, FieldValue, Index,
-        Label,
+        ExprParen, ExprPath, ExprRange, ExprRawAddr, ExprReference, ExprRepeat, ExprReturn,
+        ExprStruct, ExprTry, ExprTryBlock, ExprTuple, ExprUnary, ExprUnsafe, ExprWhile, ExprYield,
+        FieldValue, Index, Label,
     },
 };
 
@@ -21,8 +21,6 @@ ast_struct! {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub(crate) attrs: Vec<Attribute>,
         pub(crate) pat: Pat,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub(crate) guard: Option<Box<Expr>>,
         pub(crate) body: Box<Expr>,
         // #[serde(default, skip_serializing_if = "not")]
         // pub(crate) comma: bool,
@@ -69,6 +67,7 @@ pub(crate) fn requires_terminator(expr: &Expr) -> bool {
         | Expr::Try(_)
         | Expr::Tuple(_)
         | Expr::Unary(_)
+        | Expr::RawAddr(_)
         | Expr::Yield(_)
         | Expr::Verbatim(_) => true
     }
@@ -90,12 +89,7 @@ mod convert {
                     assert!(other.comma.is_some(), "expected `,`");
                 }
 
-                Arm {
-                    attrs: other.attrs.map_into(),
-                    pat: other.pat.ref_into(),
-                    guard: other.guard.ref_map(|(_, x)| x.map_into()),
-                    body,
-                }
+                Arm { attrs: other.attrs.map_into(), pat: other.pat.ref_into(), body }
             })
             .collect()
     }
@@ -129,12 +123,7 @@ mod convert {
                 assert!(other.comma.is_some(), "expected `,`");
             }
 
-            Self {
-                attrs: other.attrs.map_into(),
-                pat: other.pat.ref_into(),
-                guard: other.guard.ref_map(|(_, x)| x.map_into()),
-                body,
-            }
+            Self { attrs: other.attrs.map_into(), pat: other.pat.ref_into(), body }
         }
     }
     impl From<&Arm> for syn::Arm {
@@ -142,7 +131,6 @@ mod convert {
             Self {
                 attrs: other.attrs.map_into(),
                 pat: other.pat.ref_into(),
-                guard: other.guard.ref_map(|x| (default(), x.map_into())),
                 fat_arrow_token: default(),
                 body: other.body.map_into(),
                 comma: default_or_none(requires_terminator(&other.body)),

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use super::*;
+pub use crate::ast_struct::File;
+use crate::ast_struct::ItemImpl;
+
+mod convert {
+    use super::*;
+
+    // File
+    syn_trait_impl!(syn::File);
+    impl From<&syn::File> for File {
+        fn from(node: &syn::File) -> Self {
+            Self {
+                shebang: node.shebang.clone(),
+                attrs: node.attrs.map_into(),
+                items: node.items.map_into(),
+            }
+        }
+    }
+    impl From<&File> for syn::File {
+        fn from(node: &File) -> Self {
+            Self {
+                shebang: node.shebang.clone(),
+                frontmatter: None,
+                attrs: node.attrs.map_into(),
+                items: node.items.map_into(),
+            }
+        }
+    }
+
+    // ItemImpl
+    syn_trait_impl!(syn::ItemImpl);
+    impl From<&syn::ItemImpl> for ItemImpl {
+        fn from(node: &syn::ItemImpl) -> Self {
+            Self {
+                attrs: node.attrs.map_into(),
+                modifiers: node.modifiers.ref_into(),
+                unsafety: node.unsafety.is_some(),
+                generics: node.generics.ref_into(),
+                trait_: node.trait_.ref_map(|(_0, _1)| _0.ref_into()),
+                self_ty: node.self_ty.map_into(),
+                items: node.items.map_into(),
+            }
+        }
+    }
+    impl From<&ItemImpl> for syn::ItemImpl {
+        fn from(node: &ItemImpl) -> Self {
+            Self {
+                attrs: node.attrs.map_into(),
+                modifiers: node.modifiers.ref_into(),
+                unsafety: default_or_none(node.unsafety),
+                impl_token: default(),
+                generics: node.generics.ref_into(),
+                trait_: node.trait_.ref_map(|_0| (_0.ref_into(), default())),
+                self_ty: node.self_ty.map_into(),
+                brace_token: default(),
+                items: node.items.map_into(),
+            }
+        }
+    }
+}

--- a/src/gen/ast_enum.rs
+++ b/src/gen/ast_enum.rs
@@ -106,6 +106,7 @@ pub enum Expr {
     Paren(ExprParen),
     Path(ExprPath),
     Range(ExprRange),
+    RawAddr(ExprRawAddr),
     Reference(ExprReference),
     Repeat(ExprRepeat),
     Return(ExprReturn),
@@ -118,13 +119,6 @@ pub enum Expr {
     Verbatim(TokenStream),
     While(ExprWhile),
     Yield(ExprYield),
-}
-/// An adapter for [`enum@syn::FieldMutability`].
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum FieldMutability {
-    None,
 }
 /// An adapter for [`enum@syn::Fields`].
 #[derive(Serialize, Deserialize)]
@@ -183,11 +177,6 @@ pub enum ImplItem {
     Macro(ImplItemMacro),
     Verbatim(TokenStream),
 }
-/// An adapter for [`enum@syn::ImplRestriction`].
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum ImplRestriction {}
 /// An adapter for [`enum@syn::Item`].
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -281,6 +270,13 @@ pub enum PathArguments {
     AngleBracketed(AngleBracketedGenericArguments),
     Parenthesized(ParenthesizedGenericArguments),
 }
+/// An adapter for [`enum@syn::PointerMutability`].
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PointerMutability {
+    Const,
+    Mut,
+}
 /// An adapter for [`enum@syn::RangeLimits`].
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -290,6 +286,14 @@ pub enum RangeLimits {
     #[serde(rename = "..=")]
     Closed,
 }
+/// An adapter for [`enum@syn::Safety`].
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Safety {
+    Safe,
+    Unsafe,
+    Default,
+}
 /// An adapter for [`enum@syn::StaticMutability`].
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -298,13 +302,6 @@ pub enum StaticMutability {
     #[serde(rename = "mut")]
     Mut,
     None,
-}
-/// An adapter for [`enum@syn::TraitBoundModifier`].
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TraitBoundModifier {
-    None,
-    Maybe,
 }
 /// An adapter for [`enum@syn::TraitItem`].
 #[derive(Serialize, Deserialize)]
@@ -323,7 +320,7 @@ pub enum TraitItem {
 #[non_exhaustive]
 pub enum Type {
     Array(TypeArray),
-    BareFn(TypeBareFn),
+    FnPtr(TypeFnPtr),
     Group(TypeGroup),
     ImplTrait(TypeImplTrait),
     #[serde(rename = "_")]
@@ -381,6 +378,13 @@ pub enum Visibility {
     Public,
     Restricted(VisRestricted),
     Inherited,
+}
+/// An adapter for [`enum@syn::WhereClausePlacement`].
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WhereClausePlacement {
+    Early,
+    Late,
 }
 /// An adapter for [`enum@syn::WherePredicate`].
 #[derive(Serialize, Deserialize)]

--- a/src/gen/ast_struct.rs
+++ b/src/gen/ast_struct.rs
@@ -40,25 +40,6 @@ pub struct Attribute {
     pub(crate) style: AttrStyle,
     pub(crate) meta: Meta,
 }
-/// An adapter for [`struct@syn::BareFnArg`].
-#[derive(Serialize, Deserialize)]
-pub struct BareFnArg {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub(crate) attrs: Vec<Attribute>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) name: Option<Ident>,
-    pub(crate) ty: Type,
-}
-/// An adapter for [`struct@syn::BareVariadic`].
-#[derive(Serialize, Deserialize)]
-pub struct BareVariadic {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub(crate) attrs: Vec<Attribute>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) name: Option<Ident>,
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) comma: bool,
-}
 /// An adapter for [`struct@syn::Block`].
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
@@ -72,6 +53,13 @@ pub struct Block {
 pub struct BoundLifetimes {
     pub(crate) lifetimes: Punctuated<GenericParam>,
 }
+/// An adapter for [`struct@syn::ConstModifiers`].
+#[derive(Serialize, Deserialize)]
+pub struct ConstModifiers {
+    #[serde(rename = "default")]
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) defaultness: bool,
+}
 /// An adapter for [`struct@syn::ConstParam`].
 #[derive(Serialize, Deserialize)]
 pub struct ConstParam {
@@ -79,8 +67,6 @@ pub struct ConstParam {
     pub(crate) attrs: Vec<Attribute>,
     pub(crate) ident: Ident,
     pub(crate) ty: Type,
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) eq_token: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) default: Option<Expr>,
 }
@@ -180,9 +166,6 @@ pub struct ExprClosure {
     #[serde(rename = "const")]
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) constness: bool,
-    #[serde(rename = "static")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) movability: bool,
     #[serde(rename = "async")]
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) asyncness: bool,
@@ -341,6 +324,14 @@ pub struct ExprRange {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) end: Option<Box<Expr>>,
 }
+/// An adapter for [`struct@syn::ExprRawAddr`].
+#[derive(Serialize, Deserialize)]
+pub struct ExprRawAddr {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
+    pub(crate) mutability: PointerMutability,
+    pub(crate) expr: Box<Expr>,
+}
 /// An adapter for [`struct@syn::ExprReference`].
 #[derive(Serialize, Deserialize)]
 pub struct ExprReference {
@@ -480,6 +471,23 @@ pub struct File {
     pub(crate) attrs: Vec<Attribute>,
     pub(crate) items: Vec<Item>,
 }
+/// An adapter for [`struct@syn::FnModifiers`].
+#[derive(Serialize, Deserialize)]
+pub struct FnModifiers {
+    #[serde(rename = "default")]
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) defaultness: bool,
+}
+/// An adapter for [`struct@syn::FnPtrVariadic`].
+#[derive(Serialize, Deserialize)]
+pub struct FnPtrVariadic {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<Ident>,
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) comma: bool,
+}
 /// An adapter for [`struct@syn::ForeignItemFn`].
 #[derive(Serialize, Deserialize)]
 pub struct ForeignItemFn {
@@ -487,6 +495,7 @@ pub struct ForeignItemFn {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
+    pub(crate) modifiers: FnModifiers,
     #[serde(flatten)]
     pub(crate) sig: Signature,
 }
@@ -507,6 +516,8 @@ pub struct ForeignItemStatic {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
+    #[serde(default, skip_serializing_if = "Safety::is_default")]
+    pub(crate) safety: Safety,
     #[serde(rename = "mut")]
     #[serde(default, skip_serializing_if = "StaticMutability::is_none")]
     pub(crate) mutability: StaticMutability,
@@ -520,6 +531,7 @@ pub struct ForeignItemType {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
+    pub(crate) modifiers: TypeModifiers,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
@@ -531,9 +543,7 @@ pub struct ImplItemConst {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
-    #[serde(rename = "default")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) defaultness: bool,
+    pub(crate) modifiers: ConstModifiers,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
@@ -547,9 +557,7 @@ pub struct ImplItemFn {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
-    #[serde(rename = "default")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) defaultness: bool,
+    pub(crate) modifiers: FnModifiers,
     #[serde(flatten)]
     pub(crate) sig: Signature,
     #[serde(rename = "stmts")]
@@ -572,13 +580,20 @@ pub struct ImplItemType {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
-    #[serde(rename = "default")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) defaultness: bool,
+    pub(crate) modifiers: TypeModifiers,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
     pub(crate) ty: Type,
+}
+/// An adapter for [`struct@syn::ImplModifiers`].
+#[derive(Serialize, Deserialize)]
+pub struct ImplModifiers {
+    #[serde(rename = "default")]
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) defaultness: bool,
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) polarity: bool,
 }
 /// An adapter for [`struct@syn::Index`].
 #[derive(Serialize, Deserialize)]
@@ -593,6 +608,7 @@ pub struct ItemConst {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
+    pub(crate) modifiers: ConstModifiers,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
@@ -629,6 +645,7 @@ pub struct ItemFn {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
+    pub(crate) modifiers: FnModifiers,
     #[serde(flatten)]
     pub(crate) sig: Signature,
     #[serde(rename = "stmts")]
@@ -650,9 +667,7 @@ pub struct ItemForeignMod {
 pub struct ItemImpl {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) attrs: Vec<Attribute>,
-    #[serde(rename = "default")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) defaultness: bool,
+    pub(crate) modifiers: ImplModifiers,
     #[serde(rename = "unsafe")]
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) unsafety: bool,
@@ -660,7 +675,7 @@ pub struct ItemImpl {
     pub(crate) generics: Generics,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(rename = "trait")]
-    pub(crate) trait_: Option<(bool, Path)>,
+    pub(crate) trait_: Option<Path>,
     pub(crate) self_ty: Box<Type>,
     pub(crate) items: Vec<ImplItem>,
 }
@@ -697,14 +712,10 @@ pub struct ItemTrait {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
+    pub(crate) modifiers: TraitModifiers,
     #[serde(rename = "unsafe")]
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) unsafety: bool,
-    #[serde(rename = "auto")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) auto_token: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) restriction: Option<ImplRestriction>,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
@@ -733,10 +744,12 @@ pub struct ItemType {
     pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Visibility::is_inherited")]
     pub(crate) vis: Visibility,
+    pub(crate) modifiers: TypeModifiers,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
     pub(crate) ty: Box<Type>,
+    pub(crate) where_clause_placement: WhereClausePlacement,
 }
 /// An adapter for [`struct@syn::ItemUnion`].
 #[derive(Serialize, Deserialize)]
@@ -782,6 +795,7 @@ pub struct LifetimeParam {
     pub(crate) lifetime: Lifetime,
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) colon_token: bool,
+    #[serde(default, skip_serializing_if = "Punctuated::is_empty")]
     pub(crate) bounds: Punctuated<Lifetime>,
 }
 /// An adapter for [`struct@syn::LitBool`].
@@ -826,10 +840,19 @@ pub struct MetaNameValue {
     pub(crate) path: Path,
     pub(crate) value: Expr,
 }
+/// An adapter for [`struct@syn::NamedArg`].
+#[derive(Serialize, Deserialize)]
+pub struct NamedArg {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<Ident>,
+    pub(crate) ty: Type,
+}
 /// An adapter for [`struct@syn::ParenthesizedGenericArguments`].
 #[derive(Serialize, Deserialize)]
 pub struct ParenthesizedGenericArguments {
-    pub(crate) inputs: Punctuated<Type>,
+    pub(crate) inputs: Punctuated<NamedArg>,
     #[serde(default)]
     pub(crate) output: ReturnType,
 }
@@ -938,6 +961,8 @@ pub struct PathSegment {
 /// An adapter for [`struct@syn::PredicateLifetime`].
 #[derive(Serialize, Deserialize)]
 pub struct PredicateLifetime {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     pub(crate) lifetime: Lifetime,
     pub(crate) bounds: Punctuated<Lifetime>,
 }
@@ -958,9 +983,8 @@ pub struct Signature {
     #[serde(rename = "async")]
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) asyncness: bool,
-    #[serde(rename = "unsafe")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) unsafety: bool,
+    #[serde(default, skip_serializing_if = "Safety::is_default")]
+    pub(crate) safety: Safety,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) abi: Option<Abi>,
     pub(crate) ident: Ident,
@@ -987,10 +1011,10 @@ pub struct StmtMacro {
 pub struct TraitBound {
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) paren_token: bool,
-    #[serde(default, skip_serializing_if = "TraitBoundModifier::is_none")]
-    pub(crate) modifier: TraitBoundModifier,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) lifetimes: Option<BoundLifetimes>,
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) maybe: bool,
     pub(crate) path: Path,
 }
 /// An adapter for [`struct@syn::TraitItemConst`].
@@ -998,6 +1022,7 @@ pub struct TraitBound {
 pub struct TraitItemConst {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) attrs: Vec<Attribute>,
+    pub(crate) modifiers: ConstModifiers,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
@@ -1020,6 +1045,7 @@ pub struct TraitItemMacro {
 pub struct TraitItemType {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) attrs: Vec<Attribute>,
+    pub(crate) modifiers: TypeModifiers,
     pub(crate) ident: Ident,
     #[serde(default, skip_serializing_if = "Generics::is_none")]
     pub(crate) generics: Generics,
@@ -1030,15 +1056,26 @@ pub struct TraitItemType {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) default: Option<Type>,
 }
+/// An adapter for [`struct@syn::TraitModifiers`].
+#[derive(Serialize, Deserialize)]
+pub struct TraitModifiers {
+    #[serde(rename = "auto")]
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) auto_token: bool,
+}
 /// An adapter for [`struct@syn::TypeArray`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeArray {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     pub(crate) elem: Box<Type>,
     pub(crate) len: Expr,
 }
-/// An adapter for [`struct@syn::TypeBareFn`].
+/// An adapter for [`struct@syn::TypeFnPtr`].
 #[derive(Serialize, Deserialize)]
-pub struct TypeBareFn {
+pub struct TypeFnPtr {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) lifetimes: Option<BoundLifetimes>,
     #[serde(rename = "unsafe")]
@@ -1046,27 +1083,40 @@ pub struct TypeBareFn {
     pub(crate) unsafety: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) abi: Option<Abi>,
-    pub(crate) inputs: Punctuated<BareFnArg>,
+    pub(crate) inputs: Punctuated<NamedArg>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) variadic: Option<BareVariadic>,
+    pub(crate) variadic: Option<FnPtrVariadic>,
     #[serde(default)]
     pub(crate) output: ReturnType,
 }
 /// An adapter for [`struct@syn::TypeGroup`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeGroup {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     pub(crate) elem: Box<Type>,
 }
 /// An adapter for [`struct@syn::TypeImplTrait`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeImplTrait {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     pub(crate) bounds: Punctuated<TypeParamBound>,
 }
 /// An adapter for [`struct@syn::TypeMacro`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeMacro {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     #[serde(flatten)]
     pub(crate) mac: Macro,
+}
+/// An adapter for [`struct@syn::TypeModifiers`].
+#[derive(Serialize, Deserialize)]
+pub struct TypeModifiers {
+    #[serde(rename = "default")]
+    #[serde(default, skip_serializing_if = "not")]
+    pub(crate) defaultness: bool,
 }
 /// An adapter for [`struct@syn::TypeParam`].
 #[derive(Serialize, Deserialize)]
@@ -1078,19 +1128,21 @@ pub struct TypeParam {
     pub(crate) colon_token: bool,
     #[serde(default, skip_serializing_if = "Punctuated::is_empty")]
     pub(crate) bounds: Punctuated<TypeParamBound>,
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) eq_token: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) default: Option<Type>,
 }
 /// An adapter for [`struct@syn::TypeParen`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeParen {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     pub(crate) elem: Box<Type>,
 }
 /// An adapter for [`struct@syn::TypePath`].
 #[derive(Serialize, Deserialize)]
 pub struct TypePath {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) qself: Option<QSelf>,
     #[serde(flatten)]
@@ -1099,17 +1151,16 @@ pub struct TypePath {
 /// An adapter for [`struct@syn::TypePtr`].
 #[derive(Serialize, Deserialize)]
 pub struct TypePtr {
-    #[serde(rename = "const")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) const_token: bool,
-    #[serde(rename = "mut")]
-    #[serde(default, skip_serializing_if = "not")]
-    pub(crate) mutability: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
+    pub(crate) mutability: PointerMutability,
     pub(crate) elem: Box<Type>,
 }
 /// An adapter for [`struct@syn::TypeReference`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeReference {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) lifetime: Option<Lifetime>,
     #[serde(rename = "mut")]
@@ -1120,11 +1171,15 @@ pub struct TypeReference {
 /// An adapter for [`struct@syn::TypeSlice`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeSlice {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     pub(crate) elem: Box<Type>,
 }
 /// An adapter for [`struct@syn::TypeTraitObject`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeTraitObject {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     #[serde(rename = "dyn")]
     #[serde(default, skip_serializing_if = "not")]
     pub(crate) dyn_token: bool,
@@ -1133,6 +1188,8 @@ pub struct TypeTraitObject {
 /// An adapter for [`struct@syn::TypeTuple`].
 #[derive(Serialize, Deserialize)]
 pub struct TypeTuple {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) attrs: Vec<Attribute>,
     pub(crate) elems: Punctuated<Type>,
 }
 /// An adapter for [`struct@syn::UseGroup`].

--- a/src/gen/convert.rs
+++ b/src/gen/convert.rs
@@ -120,45 +120,6 @@ impl From<&Attribute> for syn::Attribute {
         }
     }
 }
-syn_trait_impl!(syn::BareFnArg);
-impl From<&syn::BareFnArg> for BareFnArg {
-    fn from(node: &syn::BareFnArg) -> Self {
-        Self {
-            attrs: node.attrs.map_into(),
-            name: node.name.ref_map(|(_0, _1)| (*_0).ref_into()),
-            ty: node.ty.ref_into(),
-        }
-    }
-}
-impl From<&BareFnArg> for syn::BareFnArg {
-    fn from(node: &BareFnArg) -> Self {
-        Self {
-            attrs: node.attrs.map_into(),
-            name: node.name.ref_map(|_0| ((*_0).ref_into(), default())),
-            ty: node.ty.ref_into(),
-        }
-    }
-}
-syn_trait_impl!(syn::BareVariadic);
-impl From<&syn::BareVariadic> for BareVariadic {
-    fn from(node: &syn::BareVariadic) -> Self {
-        Self {
-            attrs: node.attrs.map_into(),
-            name: node.name.ref_map(|(_0, _1)| (*_0).ref_into()),
-            comma: node.comma.is_some(),
-        }
-    }
-}
-impl From<&BareVariadic> for syn::BareVariadic {
-    fn from(node: &BareVariadic) -> Self {
-        Self {
-            attrs: node.attrs.map_into(),
-            name: node.name.ref_map(|_0| ((*_0).ref_into(), default())),
-            dots: default(),
-            comma: default_or_none(node.comma),
-        }
-    }
-}
 syn_trait_impl!(syn::BinOp);
 impl From<&syn::BinOp> for BinOp {
     fn from(node: &syn::BinOp) -> Self {
@@ -263,6 +224,21 @@ impl From<&BoundLifetimes> for syn::BoundLifetimes {
         }
     }
 }
+syn_trait_impl!(syn::ConstModifiers);
+impl From<&syn::ConstModifiers> for ConstModifiers {
+    fn from(node: &syn::ConstModifiers) -> Self {
+        Self {
+            defaultness: node.defaultness.is_some(),
+        }
+    }
+}
+impl From<&ConstModifiers> for syn::ConstModifiers {
+    fn from(node: &ConstModifiers) -> Self {
+        let mut _r = <syn::ConstModifiers>::default();
+        _r.defaultness = default_or_none(node.defaultness);
+        _r
+    }
+}
 syn_trait_impl!(syn::ConstParam);
 impl From<&syn::ConstParam> for ConstParam {
     fn from(node: &syn::ConstParam) -> Self {
@@ -270,8 +246,7 @@ impl From<&syn::ConstParam> for ConstParam {
             attrs: node.attrs.map_into(),
             ident: node.ident.ref_into(),
             ty: node.ty.ref_into(),
-            eq_token: node.eq_token.is_some(),
-            default: node.default.map_into(),
+            default: node.default.ref_map(|(_0, _1)| (*_1).ref_into()),
         }
     }
 }
@@ -283,8 +258,7 @@ impl From<&ConstParam> for syn::ConstParam {
             ident: node.ident.ref_into(),
             colon_token: default(),
             ty: node.ty.ref_into(),
-            eq_token: default_or_none(node.eq_token),
-            default: node.default.map_into(),
+            default: node.default.ref_map(|_1| (default(), (*_1).ref_into())),
         }
     }
 }
@@ -339,6 +313,7 @@ impl From<&syn::Expr> for Expr {
             syn::Expr::Paren(_0) => Expr::Paren((*_0).ref_into()),
             syn::Expr::Path(_0) => Expr::Path((*_0).ref_into()),
             syn::Expr::Range(_0) => Expr::Range((*_0).ref_into()),
+            syn::Expr::RawAddr(_0) => Expr::RawAddr((*_0).ref_into()),
             syn::Expr::Reference(_0) => Expr::Reference((*_0).ref_into()),
             syn::Expr::Repeat(_0) => Expr::Repeat((*_0).ref_into()),
             syn::Expr::Return(_0) => Expr::Return((*_0).ref_into()),
@@ -385,6 +360,7 @@ impl From<&Expr> for syn::Expr {
             Expr::Paren(_0) => syn::Expr::Paren((*_0).ref_into()),
             Expr::Path(_0) => syn::Expr::Path((*_0).ref_into()),
             Expr::Range(_0) => syn::Expr::Range((*_0).ref_into()),
+            Expr::RawAddr(_0) => syn::Expr::RawAddr((*_0).ref_into()),
             Expr::Reference(_0) => syn::Expr::Reference((*_0).ref_into()),
             Expr::Repeat(_0) => syn::Expr::Repeat((*_0).ref_into()),
             Expr::Return(_0) => syn::Expr::Return((*_0).ref_into()),
@@ -453,6 +429,7 @@ impl From<&ExprAsync> for syn::ExprAsync {
         Self {
             attrs: node.attrs.map_into(),
             async_token: default(),
+            modifiers: <syn::BlockModifiers>::default(),
             capture: default_or_none(node.capture),
             block: node.block.ref_into(),
         }
@@ -584,7 +561,6 @@ impl From<&syn::ExprClosure> for ExprClosure {
             attrs: node.attrs.map_into(),
             lifetimes: node.lifetimes.map_into(),
             constness: node.constness.is_some(),
-            movability: node.movability.is_some(),
             asyncness: node.asyncness.is_some(),
             capture: node.capture.is_some(),
             inputs: node.inputs.map_into(),
@@ -598,13 +574,13 @@ impl From<&ExprClosure> for syn::ExprClosure {
         Self {
             attrs: node.attrs.map_into(),
             lifetimes: node.lifetimes.map_into(),
+            modifiers: <syn::ClosureModifiers>::default(),
             constness: default_or_none(node.constness),
-            movability: default_or_none(node.movability),
             asyncness: default_or_none(node.asyncness),
             capture: default_or_none(node.capture),
-            or1_token: default(),
+            inputs_begin: default(),
             inputs: node.inputs.map_into(),
-            or2_token: default(),
+            inputs_end: default(),
             output: node.output.ref_into(),
             body: node.body.map_into(),
         }
@@ -624,6 +600,7 @@ impl From<&ExprConst> for syn::ExprConst {
         Self {
             attrs: node.attrs.map_into(),
             const_token: default(),
+            modifiers: <syn::BlockModifiers>::default(),
             block: node.block.ref_into(),
         }
     }
@@ -925,6 +902,27 @@ impl From<&ExprRange> for syn::ExprRange {
         }
     }
 }
+syn_trait_impl!(syn::ExprRawAddr);
+impl From<&syn::ExprRawAddr> for ExprRawAddr {
+    fn from(node: &syn::ExprRawAddr) -> Self {
+        Self {
+            attrs: node.attrs.map_into(),
+            mutability: node.mutability.ref_into(),
+            expr: node.expr.map_into(),
+        }
+    }
+}
+impl From<&ExprRawAddr> for syn::ExprRawAddr {
+    fn from(node: &ExprRawAddr) -> Self {
+        Self {
+            attrs: node.attrs.map_into(),
+            and_token: default(),
+            raw: default(),
+            mutability: node.mutability.ref_into(),
+            expr: node.expr.map_into(),
+        }
+    }
+}
 syn_trait_impl!(syn::ExprReference);
 impl From<&syn::ExprReference> for ExprReference {
     fn from(node: &syn::ExprReference) -> Self {
@@ -1042,6 +1040,7 @@ impl From<&ExprTryBlock> for syn::ExprTryBlock {
         Self {
             attrs: node.attrs.map_into(),
             try_token: default(),
+            modifiers: <syn::BlockModifiers>::default(),
             block: node.block.ref_into(),
         }
     }
@@ -1147,10 +1146,10 @@ impl From<&syn::Field> for Field {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            mutability: node.mutability.ref_into(),
             ident: node.ident.map_into(),
             colon_token: node.colon_token.is_some(),
             ty: node.ty.ref_into(),
+            default: node.default.ref_map(|(_0, _1)| (*_1).ref_into()),
         }
     }
 }
@@ -1159,26 +1158,11 @@ impl From<&Field> for syn::Field {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            mutability: node.mutability.ref_into(),
+            modifiers: <syn::FieldModifiers>::default(),
             ident: node.ident.map_into(),
             colon_token: default_or_none(node.colon_token),
             ty: node.ty.ref_into(),
-        }
-    }
-}
-syn_trait_impl!(syn::FieldMutability);
-impl From<&syn::FieldMutability> for FieldMutability {
-    fn from(node: &syn::FieldMutability) -> Self {
-        match node {
-            syn::FieldMutability::None => FieldMutability::None,
-            _ => unreachable!(),
-        }
-    }
-}
-impl From<&FieldMutability> for syn::FieldMutability {
-    fn from(node: &FieldMutability) -> Self {
-        match node {
-            FieldMutability::None => syn::FieldMutability::None,
+            default: node.default.ref_map(|_1| (default(), (*_1).ref_into())),
         }
     }
 }
@@ -1275,25 +1259,6 @@ impl From<&FieldsUnnamed> for syn::FieldsUnnamed {
         }
     }
 }
-syn_trait_impl!(syn::File);
-impl From<&syn::File> for File {
-    fn from(node: &syn::File) -> Self {
-        Self {
-            shebang: node.shebang.map_into(),
-            attrs: node.attrs.map_into(),
-            items: node.items.map_into(),
-        }
-    }
-}
-impl From<&File> for syn::File {
-    fn from(node: &File) -> Self {
-        Self {
-            shebang: node.shebang.map_into(),
-            attrs: node.attrs.map_into(),
-            items: node.items.map_into(),
-        }
-    }
-}
 syn_trait_impl!(syn::FnArg);
 impl From<&syn::FnArg> for FnArg {
     fn from(node: &syn::FnArg) -> Self {
@@ -1308,6 +1273,41 @@ impl From<&FnArg> for syn::FnArg {
         match node {
             FnArg::Receiver(_0) => syn::FnArg::Receiver((*_0).ref_into()),
             FnArg::Typed(_0) => syn::FnArg::Typed((*_0).ref_into()),
+        }
+    }
+}
+syn_trait_impl!(syn::FnModifiers);
+impl From<&syn::FnModifiers> for FnModifiers {
+    fn from(node: &syn::FnModifiers) -> Self {
+        Self {
+            defaultness: node.defaultness.is_some(),
+        }
+    }
+}
+impl From<&FnModifiers> for syn::FnModifiers {
+    fn from(node: &FnModifiers) -> Self {
+        let mut _r = <syn::FnModifiers>::default();
+        _r.defaultness = default_or_none(node.defaultness);
+        _r
+    }
+}
+syn_trait_impl!(syn::FnPtrVariadic);
+impl From<&syn::FnPtrVariadic> for FnPtrVariadic {
+    fn from(node: &syn::FnPtrVariadic) -> Self {
+        Self {
+            attrs: node.attrs.map_into(),
+            name: node.name.ref_map(|(_0, _1)| (*_0).ref_into()),
+            comma: node.comma.is_some(),
+        }
+    }
+}
+impl From<&FnPtrVariadic> for syn::FnPtrVariadic {
+    fn from(node: &FnPtrVariadic) -> Self {
+        Self {
+            attrs: node.attrs.map_into(),
+            name: node.name.ref_map(|_0| ((*_0).ref_into(), default())),
+            dots: default(),
+            comma: default_or_none(node.comma),
         }
     }
 }
@@ -1341,6 +1341,7 @@ impl From<&syn::ForeignItemFn> for ForeignItemFn {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             sig: node.sig.ref_into(),
         }
     }
@@ -1350,6 +1351,7 @@ impl From<&ForeignItemFn> for syn::ForeignItemFn {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             sig: node.sig.ref_into(),
             semi_token: default(),
         }
@@ -1380,6 +1382,7 @@ impl From<&syn::ForeignItemStatic> for ForeignItemStatic {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            safety: node.safety.ref_into(),
             mutability: node.mutability.ref_into(),
             ident: node.ident.ref_into(),
             ty: node.ty.map_into(),
@@ -1391,6 +1394,7 @@ impl From<&ForeignItemStatic> for syn::ForeignItemStatic {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            safety: node.safety.ref_into(),
             static_token: default(),
             mutability: node.mutability.ref_into(),
             ident: node.ident.ref_into(),
@@ -1406,6 +1410,7 @@ impl From<&syn::ForeignItemType> for ForeignItemType {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
         }
@@ -1416,6 +1421,7 @@ impl From<&ForeignItemType> for syn::ForeignItemType {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             type_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -1514,7 +1520,7 @@ impl From<&syn::ImplItemConst> for ImplItemConst {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            defaultness: node.defaultness.is_some(),
+            modifiers: node.modifiers.ref_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             ty: node.ty.ref_into(),
@@ -1527,7 +1533,7 @@ impl From<&ImplItemConst> for syn::ImplItemConst {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            defaultness: default_or_none(node.defaultness),
+            modifiers: node.modifiers.ref_into(),
             const_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -1545,7 +1551,7 @@ impl From<&syn::ImplItemFn> for ImplItemFn {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            defaultness: node.defaultness.is_some(),
+            modifiers: node.modifiers.ref_into(),
             sig: node.sig.ref_into(),
             block: node.block.ref_into(),
         }
@@ -1556,7 +1562,7 @@ impl From<&ImplItemFn> for syn::ImplItemFn {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            defaultness: default_or_none(node.defaultness),
+            modifiers: node.modifiers.ref_into(),
             sig: node.sig.ref_into(),
             block: node.block.ref_into(),
         }
@@ -1587,7 +1593,7 @@ impl From<&syn::ImplItemType> for ImplItemType {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            defaultness: node.defaultness.is_some(),
+            modifiers: node.modifiers.ref_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             ty: node.ty.ref_into(),
@@ -1599,7 +1605,7 @@ impl From<&ImplItemType> for syn::ImplItemType {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
-            defaultness: default_or_none(node.defaultness),
+            modifiers: node.modifiers.ref_into(),
             type_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -1609,19 +1615,21 @@ impl From<&ImplItemType> for syn::ImplItemType {
         }
     }
 }
-syn_trait_impl!(syn::ImplRestriction);
-impl From<&syn::ImplRestriction> for ImplRestriction {
-    fn from(node: &syn::ImplRestriction) -> Self {
-        match node {
-            _ => unreachable!(),
+syn_trait_impl!(syn::ImplModifiers);
+impl From<&syn::ImplModifiers> for ImplModifiers {
+    fn from(node: &syn::ImplModifiers) -> Self {
+        Self {
+            defaultness: node.defaultness.is_some(),
+            polarity: node.polarity.is_some(),
         }
     }
 }
-impl From<&ImplRestriction> for syn::ImplRestriction {
-    fn from(node: &ImplRestriction) -> Self {
-        match node {
-            _ => unreachable!(),
-        }
+impl From<&ImplModifiers> for syn::ImplModifiers {
+    fn from(node: &ImplModifiers) -> Self {
+        let mut _r = <syn::ImplModifiers>::default();
+        _r.defaultness = default_or_none(node.defaultness);
+        _r.polarity = default_or_none(node.polarity);
+        _r
     }
 }
 syn_trait_impl!(syn::Index);
@@ -1690,6 +1698,7 @@ impl From<&syn::ItemConst> for ItemConst {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             ty: node.ty.map_into(),
@@ -1702,6 +1711,7 @@ impl From<&ItemConst> for syn::ItemConst {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             const_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -1768,6 +1778,7 @@ impl From<&syn::ItemFn> for ItemFn {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             sig: node.sig.ref_into(),
             block: node.block.map_into(),
         }
@@ -1778,6 +1789,7 @@ impl From<&ItemFn> for syn::ItemFn {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             sig: node.sig.ref_into(),
             block: node.block.map_into(),
         }
@@ -1800,43 +1812,6 @@ impl From<&ItemForeignMod> for syn::ItemForeignMod {
             attrs: node.attrs.map_into(),
             unsafety: default_or_none(node.unsafety),
             abi: node.abi.ref_into(),
-            brace_token: default(),
-            items: node.items.map_into(),
-        }
-    }
-}
-syn_trait_impl!(syn::ItemImpl);
-impl From<&syn::ItemImpl> for ItemImpl {
-    fn from(node: &syn::ItemImpl) -> Self {
-        Self {
-            attrs: node.attrs.map_into(),
-            defaultness: node.defaultness.is_some(),
-            unsafety: node.unsafety.is_some(),
-            generics: node.generics.ref_into(),
-            trait_: node
-                .trait_
-                .ref_map(|(_0, _1, _2)| ((*_0).is_some(), (*_1).ref_into())),
-            self_ty: node.self_ty.map_into(),
-            items: node.items.map_into(),
-        }
-    }
-}
-impl From<&ItemImpl> for syn::ItemImpl {
-    fn from(node: &ItemImpl) -> Self {
-        Self {
-            attrs: node.attrs.map_into(),
-            defaultness: default_or_none(node.defaultness),
-            unsafety: default_or_none(node.unsafety),
-            impl_token: default(),
-            generics: node.generics.ref_into(),
-            trait_: node
-                .trait_
-                .ref_map(|(_0, _1)| (
-                    default_or_none((*_0)),
-                    (*_1).ref_into(),
-                    default(),
-                )),
-            self_ty: node.self_ty.map_into(),
             brace_token: default(),
             items: node.items.map_into(),
         }
@@ -1924,9 +1899,8 @@ impl From<&syn::ItemTrait> for ItemTrait {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             unsafety: node.unsafety.is_some(),
-            auto_token: node.auto_token.is_some(),
-            restriction: node.restriction.map_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             colon_token: node.colon_token.is_some(),
@@ -1940,9 +1914,8 @@ impl From<&ItemTrait> for syn::ItemTrait {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             unsafety: default_or_none(node.unsafety),
-            auto_token: default_or_none(node.auto_token),
-            restriction: node.restriction.map_into(),
             trait_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -1985,9 +1958,11 @@ impl From<&syn::ItemType> for ItemType {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             ty: node.ty.map_into(),
+            where_clause_placement: node.where_clause_placement.ref_into(),
         }
     }
 }
@@ -1996,12 +1971,14 @@ impl From<&ItemType> for syn::ItemType {
         Self {
             attrs: node.attrs.map_into(),
             vis: node.vis.ref_into(),
+            modifiers: node.modifiers.ref_into(),
             type_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             eq_token: default(),
             ty: node.ty.map_into(),
             semi_token: default(),
+            where_clause_placement: node.where_clause_placement.ref_into(),
         }
     }
 }
@@ -2162,6 +2139,7 @@ impl From<&Local> for syn::Local {
         Self {
             attrs: node.attrs.map_into(),
             let_token: default(),
+            modifiers: <syn::LocalModifiers>::default(),
             pat: node.pat.ref_into(),
             init: node.init.map_into(),
             semi_token: default(),
@@ -2295,6 +2273,25 @@ impl From<&MetaNameValue> for syn::MetaNameValue {
             path: node.path.ref_into(),
             eq_token: default(),
             value: node.value.ref_into(),
+        }
+    }
+}
+syn_trait_impl!(syn::NamedArg);
+impl From<&syn::NamedArg> for NamedArg {
+    fn from(node: &syn::NamedArg) -> Self {
+        Self {
+            attrs: node.attrs.map_into(),
+            name: node.name.ref_map(|(_0, _1)| (*_0).ref_into()),
+            ty: node.ty.ref_into(),
+        }
+    }
+}
+impl From<&NamedArg> for syn::NamedArg {
+    fn from(node: &NamedArg) -> Self {
+        Self {
+            attrs: node.attrs.map_into(),
+            name: node.name.ref_map(|_0| ((*_0).ref_into(), default())),
+            ty: node.ty.ref_into(),
         }
     }
 }
@@ -2639,10 +2636,28 @@ impl From<&PathSegment> for syn::PathSegment {
         }
     }
 }
+syn_trait_impl!(syn::PointerMutability);
+impl From<&syn::PointerMutability> for PointerMutability {
+    fn from(node: &syn::PointerMutability) -> Self {
+        match node {
+            syn::PointerMutability::Const(..) => PointerMutability::Const,
+            syn::PointerMutability::Mut(..) => PointerMutability::Mut,
+        }
+    }
+}
+impl From<&PointerMutability> for syn::PointerMutability {
+    fn from(node: &PointerMutability) -> Self {
+        match node {
+            PointerMutability::Const => syn::PointerMutability::Const(default()),
+            PointerMutability::Mut => syn::PointerMutability::Mut(default()),
+        }
+    }
+}
 syn_trait_impl!(syn::PredicateLifetime);
 impl From<&syn::PredicateLifetime> for PredicateLifetime {
     fn from(node: &syn::PredicateLifetime) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             lifetime: node.lifetime.ref_into(),
             bounds: node.bounds.map_into(),
         }
@@ -2651,6 +2666,7 @@ impl From<&syn::PredicateLifetime> for PredicateLifetime {
 impl From<&PredicateLifetime> for syn::PredicateLifetime {
     fn from(node: &PredicateLifetime) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             lifetime: node.lifetime.ref_into(),
             colon_token: default(),
             bounds: node.bounds.map_into(),
@@ -2661,6 +2677,7 @@ syn_trait_impl!(syn::PredicateType);
 impl From<&syn::PredicateType> for PredicateType {
     fn from(node: &syn::PredicateType) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             lifetimes: node.lifetimes.map_into(),
             bounded_ty: node.bounded_ty.ref_into(),
             bounds: node.bounds.map_into(),
@@ -2670,6 +2687,7 @@ impl From<&syn::PredicateType> for PredicateType {
 impl From<&PredicateType> for syn::PredicateType {
     fn from(node: &PredicateType) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             lifetimes: node.lifetimes.map_into(),
             bounded_ty: node.bounded_ty.ref_into(),
             colon_token: default(),
@@ -2715,13 +2733,32 @@ impl From<&RangeLimits> for syn::RangeLimits {
         }
     }
 }
+syn_trait_impl!(syn::Safety);
+impl From<&syn::Safety> for Safety {
+    fn from(node: &syn::Safety) -> Self {
+        match node {
+            syn::Safety::Safe(..) => Safety::Safe,
+            syn::Safety::Unsafe(..) => Safety::Unsafe,
+            syn::Safety::Default => Safety::Default,
+        }
+    }
+}
+impl From<&Safety> for syn::Safety {
+    fn from(node: &Safety) -> Self {
+        match node {
+            Safety::Safe => syn::Safety::Safe(default()),
+            Safety::Unsafe => syn::Safety::Unsafe(default()),
+            Safety::Default => syn::Safety::Default,
+        }
+    }
+}
 syn_trait_impl!(syn::Signature);
 impl From<&syn::Signature> for Signature {
     fn from(node: &syn::Signature) -> Self {
         Self {
             constness: node.constness.is_some(),
             asyncness: node.asyncness.is_some(),
-            unsafety: node.unsafety.is_some(),
+            safety: node.safety.ref_into(),
             abi: node.abi.map_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -2736,7 +2773,7 @@ impl From<&Signature> for syn::Signature {
         Self {
             constness: default_or_none(node.constness),
             asyncness: default_or_none(node.asyncness),
-            unsafety: default_or_none(node.unsafety),
+            safety: node.safety.ref_into(),
             abi: node.abi.map_into(),
             fn_token: default(),
             ident: node.ident.ref_into(),
@@ -2813,8 +2850,8 @@ impl From<&syn::TraitBound> for TraitBound {
     fn from(node: &syn::TraitBound) -> Self {
         Self {
             paren_token: node.paren_token.is_some(),
-            modifier: node.modifier.ref_into(),
             lifetimes: node.lifetimes.map_into(),
+            maybe: node.maybe.is_some(),
             path: node.path.ref_into(),
         }
     }
@@ -2823,26 +2860,10 @@ impl From<&TraitBound> for syn::TraitBound {
     fn from(node: &TraitBound) -> Self {
         Self {
             paren_token: default_or_none(node.paren_token),
-            modifier: node.modifier.ref_into(),
             lifetimes: node.lifetimes.map_into(),
+            modifiers: <syn::TraitBoundModifiers>::default(),
+            maybe: default_or_none(node.maybe),
             path: node.path.ref_into(),
-        }
-    }
-}
-syn_trait_impl!(syn::TraitBoundModifier);
-impl From<&syn::TraitBoundModifier> for TraitBoundModifier {
-    fn from(node: &syn::TraitBoundModifier) -> Self {
-        match node {
-            syn::TraitBoundModifier::None => TraitBoundModifier::None,
-            syn::TraitBoundModifier::Maybe(..) => TraitBoundModifier::Maybe,
-        }
-    }
-}
-impl From<&TraitBoundModifier> for syn::TraitBoundModifier {
-    fn from(node: &TraitBoundModifier) -> Self {
-        match node {
-            TraitBoundModifier::None => syn::TraitBoundModifier::None,
-            TraitBoundModifier::Maybe => syn::TraitBoundModifier::Maybe(default()),
         }
     }
 }
@@ -2875,6 +2896,7 @@ impl From<&syn::TraitItemConst> for TraitItemConst {
     fn from(node: &syn::TraitItemConst) -> Self {
         Self {
             attrs: node.attrs.map_into(),
+            modifiers: node.modifiers.ref_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             ty: node.ty.ref_into(),
@@ -2886,6 +2908,7 @@ impl From<&TraitItemConst> for syn::TraitItemConst {
     fn from(node: &TraitItemConst) -> Self {
         Self {
             attrs: node.attrs.map_into(),
+            modifiers: node.modifiers.ref_into(),
             const_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -2920,6 +2943,7 @@ impl From<&syn::TraitItemType> for TraitItemType {
     fn from(node: &syn::TraitItemType) -> Self {
         Self {
             attrs: node.attrs.map_into(),
+            modifiers: node.modifiers.ref_into(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
             colon_token: node.colon_token.is_some(),
@@ -2932,6 +2956,7 @@ impl From<&TraitItemType> for syn::TraitItemType {
     fn from(node: &TraitItemType) -> Self {
         Self {
             attrs: node.attrs.map_into(),
+            modifiers: node.modifiers.ref_into(),
             type_token: default(),
             ident: node.ident.ref_into(),
             generics: node.generics.ref_into(),
@@ -2942,12 +2967,27 @@ impl From<&TraitItemType> for syn::TraitItemType {
         }
     }
 }
+syn_trait_impl!(syn::TraitModifiers);
+impl From<&syn::TraitModifiers> for TraitModifiers {
+    fn from(node: &syn::TraitModifiers) -> Self {
+        Self {
+            auto_token: node.auto_token.is_some(),
+        }
+    }
+}
+impl From<&TraitModifiers> for syn::TraitModifiers {
+    fn from(node: &TraitModifiers) -> Self {
+        let mut _r = <syn::TraitModifiers>::default();
+        _r.auto_token = default_or_none(node.auto_token);
+        _r
+    }
+}
 syn_trait_impl!(syn::Type);
 impl From<&syn::Type> for Type {
     fn from(node: &syn::Type) -> Self {
         match node {
             syn::Type::Array(_0) => Type::Array((*_0).ref_into()),
-            syn::Type::BareFn(_0) => Type::BareFn((*_0).ref_into()),
+            syn::Type::FnPtr(_0) => Type::FnPtr((*_0).ref_into()),
             syn::Type::Group(_0) => Type::Group((*_0).ref_into()),
             syn::Type::ImplTrait(_0) => Type::ImplTrait((*_0).ref_into()),
             syn::Type::Infer(..) => Type::Infer,
@@ -2969,17 +3009,19 @@ impl From<&Type> for syn::Type {
     fn from(node: &Type) -> Self {
         match node {
             Type::Array(_0) => syn::Type::Array((*_0).ref_into()),
-            Type::BareFn(_0) => syn::Type::BareFn((*_0).ref_into()),
+            Type::FnPtr(_0) => syn::Type::FnPtr((*_0).ref_into()),
             Type::Group(_0) => syn::Type::Group((*_0).ref_into()),
             Type::ImplTrait(_0) => syn::Type::ImplTrait((*_0).ref_into()),
             Type::Infer => {
                 syn::Type::Infer(syn::TypeInfer {
+                    attrs: default(),
                     underscore_token: default(),
                 })
             }
             Type::Macro(_0) => syn::Type::Macro((*_0).ref_into()),
             Type::Never => {
                 syn::Type::Never(syn::TypeNever {
+                    attrs: default(),
                     bang_token: default(),
                 })
             }
@@ -2998,6 +3040,7 @@ syn_trait_impl!(syn::TypeArray);
 impl From<&syn::TypeArray> for TypeArray {
     fn from(node: &syn::TypeArray) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             elem: node.elem.map_into(),
             len: node.len.ref_into(),
         }
@@ -3006,6 +3049,7 @@ impl From<&syn::TypeArray> for TypeArray {
 impl From<&TypeArray> for syn::TypeArray {
     fn from(node: &TypeArray) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             bracket_token: default(),
             elem: node.elem.map_into(),
             semi_token: default(),
@@ -3013,10 +3057,11 @@ impl From<&TypeArray> for syn::TypeArray {
         }
     }
 }
-syn_trait_impl!(syn::TypeBareFn);
-impl From<&syn::TypeBareFn> for TypeBareFn {
-    fn from(node: &syn::TypeBareFn) -> Self {
+syn_trait_impl!(syn::TypeFnPtr);
+impl From<&syn::TypeFnPtr> for TypeFnPtr {
+    fn from(node: &syn::TypeFnPtr) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             lifetimes: node.lifetimes.map_into(),
             unsafety: node.unsafety.is_some(),
             abi: node.abi.map_into(),
@@ -3026,9 +3071,10 @@ impl From<&syn::TypeBareFn> for TypeBareFn {
         }
     }
 }
-impl From<&TypeBareFn> for syn::TypeBareFn {
-    fn from(node: &TypeBareFn) -> Self {
+impl From<&TypeFnPtr> for syn::TypeFnPtr {
+    fn from(node: &TypeFnPtr) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             lifetimes: node.lifetimes.map_into(),
             unsafety: default_or_none(node.unsafety),
             abi: node.abi.map_into(),
@@ -3043,12 +3089,16 @@ impl From<&TypeBareFn> for syn::TypeBareFn {
 syn_trait_impl!(syn::TypeGroup);
 impl From<&syn::TypeGroup> for TypeGroup {
     fn from(node: &syn::TypeGroup) -> Self {
-        Self { elem: node.elem.map_into() }
+        Self {
+            attrs: node.attrs.map_into(),
+            elem: node.elem.map_into(),
+        }
     }
 }
 impl From<&TypeGroup> for syn::TypeGroup {
     fn from(node: &TypeGroup) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             group_token: default(),
             elem: node.elem.map_into(),
         }
@@ -3058,6 +3108,7 @@ syn_trait_impl!(syn::TypeImplTrait);
 impl From<&syn::TypeImplTrait> for TypeImplTrait {
     fn from(node: &syn::TypeImplTrait) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             bounds: node.bounds.map_into(),
         }
     }
@@ -3065,6 +3116,7 @@ impl From<&syn::TypeImplTrait> for TypeImplTrait {
 impl From<&TypeImplTrait> for syn::TypeImplTrait {
     fn from(node: &TypeImplTrait) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             impl_token: default(),
             bounds: node.bounds.map_into(),
         }
@@ -3073,12 +3125,33 @@ impl From<&TypeImplTrait> for syn::TypeImplTrait {
 syn_trait_impl!(syn::TypeMacro);
 impl From<&syn::TypeMacro> for TypeMacro {
     fn from(node: &syn::TypeMacro) -> Self {
-        Self { mac: node.mac.ref_into() }
+        Self {
+            attrs: node.attrs.map_into(),
+            mac: node.mac.ref_into(),
+        }
     }
 }
 impl From<&TypeMacro> for syn::TypeMacro {
     fn from(node: &TypeMacro) -> Self {
-        Self { mac: node.mac.ref_into() }
+        Self {
+            attrs: node.attrs.map_into(),
+            mac: node.mac.ref_into(),
+        }
+    }
+}
+syn_trait_impl!(syn::TypeModifiers);
+impl From<&syn::TypeModifiers> for TypeModifiers {
+    fn from(node: &syn::TypeModifiers) -> Self {
+        Self {
+            defaultness: node.defaultness.is_some(),
+        }
+    }
+}
+impl From<&TypeModifiers> for syn::TypeModifiers {
+    fn from(node: &TypeModifiers) -> Self {
+        let mut _r = <syn::TypeModifiers>::default();
+        _r.defaultness = default_or_none(node.defaultness);
+        _r
     }
 }
 syn_trait_impl!(syn::TypeParam);
@@ -3089,8 +3162,7 @@ impl From<&syn::TypeParam> for TypeParam {
             ident: node.ident.ref_into(),
             colon_token: node.colon_token.is_some(),
             bounds: node.bounds.map_into(),
-            eq_token: node.eq_token.is_some(),
-            default: node.default.map_into(),
+            default: node.default.ref_map(|(_0, _1)| (*_1).ref_into()),
         }
     }
 }
@@ -3101,8 +3173,7 @@ impl From<&TypeParam> for syn::TypeParam {
             ident: node.ident.ref_into(),
             colon_token: default_or_none(node.colon_token),
             bounds: node.bounds.map_into(),
-            eq_token: default_or_none(node.eq_token),
-            default: node.default.map_into(),
+            default: node.default.ref_map(|_1| (default(), (*_1).ref_into())),
         }
     }
 }
@@ -3137,12 +3208,16 @@ impl From<&TypeParamBound> for syn::TypeParamBound {
 syn_trait_impl!(syn::TypeParen);
 impl From<&syn::TypeParen> for TypeParen {
     fn from(node: &syn::TypeParen) -> Self {
-        Self { elem: node.elem.map_into() }
+        Self {
+            attrs: node.attrs.map_into(),
+            elem: node.elem.map_into(),
+        }
     }
 }
 impl From<&TypeParen> for syn::TypeParen {
     fn from(node: &TypeParen) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             paren_token: default(),
             elem: node.elem.map_into(),
         }
@@ -3152,6 +3227,7 @@ syn_trait_impl!(syn::TypePath);
 impl From<&syn::TypePath> for TypePath {
     fn from(node: &syn::TypePath) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             qself: node.qself.map_into(),
             path: node.path.ref_into(),
         }
@@ -3160,6 +3236,7 @@ impl From<&syn::TypePath> for TypePath {
 impl From<&TypePath> for syn::TypePath {
     fn from(node: &TypePath) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             qself: node.qself.map_into(),
             path: node.path.ref_into(),
         }
@@ -3169,8 +3246,8 @@ syn_trait_impl!(syn::TypePtr);
 impl From<&syn::TypePtr> for TypePtr {
     fn from(node: &syn::TypePtr) -> Self {
         Self {
-            const_token: node.const_token.is_some(),
-            mutability: node.mutability.is_some(),
+            attrs: node.attrs.map_into(),
+            mutability: node.mutability.ref_into(),
             elem: node.elem.map_into(),
         }
     }
@@ -3178,9 +3255,9 @@ impl From<&syn::TypePtr> for TypePtr {
 impl From<&TypePtr> for syn::TypePtr {
     fn from(node: &TypePtr) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             star_token: default(),
-            const_token: default_or_none(node.const_token),
-            mutability: default_or_none(node.mutability),
+            mutability: node.mutability.ref_into(),
             elem: node.elem.map_into(),
         }
     }
@@ -3189,6 +3266,7 @@ syn_trait_impl!(syn::TypeReference);
 impl From<&syn::TypeReference> for TypeReference {
     fn from(node: &syn::TypeReference) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             lifetime: node.lifetime.map_into(),
             mutability: node.mutability.is_some(),
             elem: node.elem.map_into(),
@@ -3198,6 +3276,7 @@ impl From<&syn::TypeReference> for TypeReference {
 impl From<&TypeReference> for syn::TypeReference {
     fn from(node: &TypeReference) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             and_token: default(),
             lifetime: node.lifetime.map_into(),
             mutability: default_or_none(node.mutability),
@@ -3208,12 +3287,16 @@ impl From<&TypeReference> for syn::TypeReference {
 syn_trait_impl!(syn::TypeSlice);
 impl From<&syn::TypeSlice> for TypeSlice {
     fn from(node: &syn::TypeSlice) -> Self {
-        Self { elem: node.elem.map_into() }
+        Self {
+            attrs: node.attrs.map_into(),
+            elem: node.elem.map_into(),
+        }
     }
 }
 impl From<&TypeSlice> for syn::TypeSlice {
     fn from(node: &TypeSlice) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             bracket_token: default(),
             elem: node.elem.map_into(),
         }
@@ -3223,6 +3306,7 @@ syn_trait_impl!(syn::TypeTraitObject);
 impl From<&syn::TypeTraitObject> for TypeTraitObject {
     fn from(node: &syn::TypeTraitObject) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             dyn_token: node.dyn_token.is_some(),
             bounds: node.bounds.map_into(),
         }
@@ -3231,6 +3315,7 @@ impl From<&syn::TypeTraitObject> for TypeTraitObject {
 impl From<&TypeTraitObject> for syn::TypeTraitObject {
     fn from(node: &TypeTraitObject) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             dyn_token: default_or_none(node.dyn_token),
             bounds: node.bounds.map_into(),
         }
@@ -3240,6 +3325,7 @@ syn_trait_impl!(syn::TypeTuple);
 impl From<&syn::TypeTuple> for TypeTuple {
     fn from(node: &syn::TypeTuple) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             elems: node.elems.map_into(),
         }
     }
@@ -3247,6 +3333,7 @@ impl From<&syn::TypeTuple> for TypeTuple {
 impl From<&TypeTuple> for syn::TypeTuple {
     fn from(node: &TypeTuple) -> Self {
         Self {
+            attrs: node.attrs.map_into(),
             paren_token: default(),
             elems: node.elems.map_into(),
         }
@@ -3458,6 +3545,23 @@ impl From<&WhereClause> for syn::WhereClause {
         Self {
             where_token: default(),
             predicates: node.predicates.map_into(),
+        }
+    }
+}
+syn_trait_impl!(syn::WhereClausePlacement);
+impl From<&syn::WhereClausePlacement> for WhereClausePlacement {
+    fn from(node: &syn::WhereClausePlacement) -> Self {
+        match node {
+            syn::WhereClausePlacement::Early => WhereClausePlacement::Early,
+            syn::WhereClausePlacement::Late => WhereClausePlacement::Late,
+        }
+    }
+}
+impl From<&WhereClausePlacement> for syn::WhereClausePlacement {
+    fn from(node: &WhereClausePlacement) -> Self {
+        match node {
+            WhereClausePlacement::Early => syn::WhereClausePlacement::Early,
+            WhereClausePlacement::Late => syn::WhereClausePlacement::Late,
         }
     }
 }

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 pub use crate::{
-    ast_enum::{GenericParam, TraitBoundModifier, TypeParamBound, WherePredicate},
+    ast_enum::{GenericParam, TypeParamBound, WherePredicate},
     ast_struct::{
         BoundLifetimes, ConstParam, LifetimeParam, PredicateLifetime, TraitBound, TypeParam,
         WhereClause,
@@ -30,24 +30,11 @@ impl Generics {
     }
 }
 
-impl TraitBoundModifier {
-    pub(crate) fn is_none(&self) -> bool {
-        match self {
-            TraitBoundModifier::None => true,
-            TraitBoundModifier::Maybe => false,
-        }
-    }
-}
-
-impl Default for TraitBoundModifier {
-    fn default() -> Self {
-        TraitBoundModifier::None
-    }
-}
-
 ast_struct! {
     /// An adapter for [`struct@syn::PredicateType`].
     pub struct PredicateType {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub(crate) attrs: Vec<Attribute>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub(crate) lifetimes: Option<BoundLifetimes>,
         pub(crate) bounded_ty: Type,

--- a/src/item.rs
+++ b/src/item.rs
@@ -3,13 +3,15 @@
 use super::*;
 pub use crate::{
     ast_enum::{
-        FnArg, ForeignItem, ImplItem, ImplRestriction, Item, StaticMutability, TraitItem, UseTree,
+        FnArg, ForeignItem, ImplItem, Item, Safety, StaticMutability, TraitItem, UseTree,
+        WhereClausePlacement,
     },
     ast_struct::{
-        ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType, ImplItemConst,
-        ImplItemFn, ImplItemMacro, ImplItemType, ItemConst, ItemEnum, ItemExternCrate, ItemFn,
-        ItemForeignMod, ItemImpl, ItemMacro, ItemStatic, ItemTrait, ItemTraitAlias, ItemType,
-        ItemUnion, ItemUse, Signature, TraitItemConst, TraitItemMacro, TraitItemType, UseGroup,
+        ConstModifiers, FnModifiers, ForeignItemFn, ForeignItemMacro, ForeignItemStatic,
+        ForeignItemType, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplModifiers,
+        ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro,
+        ItemStatic, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Signature,
+        TraitItemConst, TraitItemMacro, TraitItemType, TraitModifiers, TypeModifiers, UseGroup,
         UseName, UsePath, UseRename, Variadic,
     },
 };
@@ -79,8 +81,8 @@ ast_struct! {
         pub(crate) mutability: bool,
         #[serde(default, skip_serializing_if = "not")]
         pub(crate) colon_token: bool,
-        // TODO: skip if colon_token=false?
-        pub(crate) ty: Box<Type>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub(crate) ty: Option<Box<Type>>,
     }
 }
 
@@ -92,6 +94,17 @@ impl StaticMutability {
 impl Default for StaticMutability {
     fn default() -> Self {
         Self::None
+    }
+}
+
+impl Safety {
+    pub(crate) fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+}
+impl Default for Safety {
+    fn default() -> Self {
+        Self::Default
     }
 }
 
@@ -151,6 +164,7 @@ mod convert {
         fn from(other: &TraitItemFn) -> Self {
             Self {
                 attrs: other.attrs.map_into(),
+                modifiers: default(),
                 sig: other.sig.ref_into(),
                 default: other.default.map_into(),
                 semi_token: default_or_none(other.default.is_none()),
@@ -162,29 +176,60 @@ mod convert {
     syn_trait_impl!(syn::Receiver);
     impl From<&syn::Receiver> for Receiver {
         fn from(node: &syn::Receiver) -> Self {
-            Self {
-                attrs: node.attrs.map_into(),
-                reference: node.reference.is_some(),
-                lifetime: node.reference.as_ref().and_then(|(_0, _1)| _1.map_into()),
-                mutability: node.mutability.is_some(),
-                colon_token: node.colon_token.is_some(),
-                ty: node.ty.map_into(),
+            use syn::ReceiverKind;
+            match &node.kind {
+                ReceiverKind::Value => Self {
+                    attrs: node.attrs.map_into(),
+                    reference: false,
+                    lifetime: None,
+                    mutability: node.mutability.is_some(),
+                    colon_token: false,
+                    ty: None,
+                },
+                ReceiverKind::Reference(_, lt, mut_) => Self {
+                    attrs: node.attrs.map_into(),
+                    reference: true,
+                    lifetime: lt.map_into(),
+                    mutability: mut_.is_some(),
+                    colon_token: false,
+                    ty: None,
+                },
+                ReceiverKind::Typed(_, ty) => Self {
+                    attrs: node.attrs.map_into(),
+                    reference: false,
+                    lifetime: None,
+                    mutability: false,
+                    colon_token: true,
+                    ty: Some(ty.map_into()),
+                },
+                _ => unreachable!(),
             }
         }
     }
     impl From<&Receiver> for syn::Receiver {
         fn from(node: &Receiver) -> Self {
+            use syn::ReceiverKind;
+            let kind = if node.colon_token {
+                ReceiverKind::Typed(
+                    default(),
+                    node.ty.as_ref().expect("ty required when colon_token").map_into(),
+                )
+            } else if node.reference {
+                ReceiverKind::Reference(
+                    default(),
+                    node.lifetime.map_into(),
+                    default_or_none(node.mutability),
+                )
+            } else {
+                ReceiverKind::Value
+            };
             Self {
                 attrs: node.attrs.map_into(),
-                reference: if node.reference {
-                    Some((default(), node.lifetime.map_into()))
-                } else {
-                    None
-                },
-                mutability: default_or_none(node.mutability),
+                mutability: default_or_none(
+                    !node.reference && !node.colon_token && node.mutability,
+                ),
                 self_token: default(),
-                colon_token: default_or_none(node.colon_token),
-                ty: node.ty.map_into(),
+                kind,
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ syn-serde = "0.3"
 ```toml
 [dependencies]
 syn-serde = { version = "0.3", features = ["json"] }
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 ```
 
 ```
@@ -95,7 +95,7 @@ similar but not identical to [Syn]. All data structures provided by syn-serde
 can be converted to the data structures of [Syn] and [proc-macro2].
 
 The data structures of syn-serde 0.3 is compatible with the data structures of
-[Syn] 2.x.
+[Syn] 3.x.
 
 [Syn]: https://github.com/dtolnay/syn
 [proc-macro2]: https://github.com/alexcrichton/proc-macro2
@@ -173,14 +173,12 @@ pub use self::expr::{
     Arm, Expr, ExprArray, ExprAssign, ExprAsync, ExprAwait, ExprBinary, ExprBlock, ExprBreak,
     ExprCall, ExprCast, ExprClosure, ExprConst, ExprContinue, ExprField, ExprForLoop, ExprGroup,
     ExprIf, ExprIndex, ExprInfer, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprMatch, ExprMethodCall,
-    ExprParen, ExprPath, ExprRange, ExprReference, ExprRepeat, ExprReturn, ExprStruct, ExprTry,
-    ExprTryBlock, ExprTuple, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, FieldValue, Index, Label,
-    Member, RangeLimits,
+    ExprParen, ExprPath, ExprRange, ExprRawAddr, ExprReference, ExprRepeat, ExprReturn, ExprStruct,
+    ExprTry, ExprTryBlock, ExprTuple, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, FieldValue,
+    Index, Label, Member, RangeLimits,
 };
 
-mod file {
-    pub use crate::ast_struct::File;
-}
+mod file;
 #[doc(hidden)]
 pub use self::file::File;
 
@@ -188,19 +186,19 @@ mod generics;
 #[doc(hidden)]
 pub use self::generics::{
     BoundLifetimes, ConstParam, GenericParam, Generics, LifetimeParam, PredicateLifetime,
-    PredicateType, TraitBound, TraitBoundModifier, TypeParam, TypeParamBound, WhereClause,
-    WherePredicate,
+    PredicateType, TraitBound, TypeParam, TypeParamBound, WhereClause, WherePredicate,
 };
 
 mod item;
 #[doc(hidden)]
 pub use self::item::{
-    FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
-    ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplRestriction, Item,
-    ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
-    ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
-    Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
-    TraitItemType, UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
+    ConstModifiers, FnArg, FnModifiers, ForeignItem, ForeignItemFn, ForeignItemMacro,
+    ForeignItemStatic, ForeignItemType, ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro,
+    ImplItemType, ImplModifiers, Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn,
+    ItemForeignMod, ItemImpl, ItemMacro, ItemMod, ItemStatic, ItemStruct, ItemTrait,
+    ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver, Safety, Signature, StaticMutability,
+    TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro, TraitItemType, TraitModifiers,
+    TypeModifiers, UseGroup, UseName, UsePath, UseRename, UseTree, Variadic, WhereClausePlacement,
 };
 
 mod lifetime {
@@ -211,9 +209,7 @@ pub use self::lifetime::Lifetime;
 
 mod lit;
 #[doc(hidden)]
-pub use self::lit::{
-    Lit, LitBool, LitByte, LitByteStr, LitChar, LitFloat, LitInt, LitStr, StrStyle,
-};
+pub use self::lit::{Lit, LitBool, LitByte, LitByteStr, LitChar, LitFloat, LitInt, LitStr};
 
 mod mac {
     pub use crate::{ast_enum::MacroDelimiter, ast_struct::Macro};
@@ -248,7 +244,7 @@ pub use self::path::{
 
 mod restriction;
 #[doc(hidden)]
-pub use self::restriction::{FieldMutability, VisRestricted, Visibility};
+pub use self::restriction::{VisRestricted, Visibility};
 
 mod stmt;
 #[doc(hidden)]
@@ -257,8 +253,8 @@ pub use self::stmt::{Block, Local, LocalInit, Stmt, StmtMacro};
 mod ty;
 #[doc(hidden)]
 pub use self::ty::{
-    Abi, BareFnArg, BareVariadic, ReturnType, Type, TypeArray, TypeBareFn, TypeGroup,
-    TypeImplTrait, TypeMacro, TypeParen, TypePath, TypePtr, TypeReference, TypeSlice,
+    Abi, FnPtrVariadic, NamedArg, PointerMutability, ReturnType, Type, TypeArray, TypeFnPtr,
+    TypeGroup, TypeImplTrait, TypeMacro, TypeParen, TypePath, TypePtr, TypeReference, TypeSlice,
     TypeTraitObject, TypeTuple,
 };
 

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -59,14 +59,6 @@ ast_struct! {
     }
 }
 
-ast_enum! {
-    /// An adapter for [`enum@syn::StrStyle`].
-    pub enum StrStyle {
-        Cooked,
-        Raw(usize),
-    }
-}
-
 mod value {
     use core::{
         char,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,7 +28,6 @@ macro_rules! syn_trait_impl {
         impl crate::sealed::Sealed for $path::$ty {}
         impl crate::Syn for $path::$ty {
             type Adapter = $ty;
-            #[allow(unreachable_code)] // For syn::ImplRestriction
             fn to_adapter(&self) -> Self::Adapter {
                 Self::Adapter::from(self)
             }

--- a/src/restriction.rs
+++ b/src/restriction.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-pub use crate::{
-    ast_enum::{FieldMutability, Visibility},
-    ast_struct::VisRestricted,
-};
+pub use crate::{ast_enum::Visibility, ast_struct::VisRestricted};
 
 impl Visibility {
     pub(crate) fn is_inherited(&self) -> bool {
@@ -13,16 +10,5 @@ impl Visibility {
 impl Default for Visibility {
     fn default() -> Self {
         Self::Inherited
-    }
-}
-
-impl FieldMutability {
-    pub(crate) fn is_none(&self) -> bool {
-        matches!(self, Self::None)
-    }
-}
-impl Default for FieldMutability {
-    fn default() -> Self {
-        Self::None
     }
 }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -4,9 +4,9 @@ use alloc::boxed::Box;
 
 use super::*;
 pub use crate::{
-    ast_enum::Type,
+    ast_enum::{PointerMutability, Type},
     ast_struct::{
-        Abi, BareFnArg, BareVariadic, TypeArray, TypeBareFn, TypeGroup, TypeImplTrait, TypeMacro,
+        Abi, FnPtrVariadic, NamedArg, TypeArray, TypeFnPtr, TypeGroup, TypeImplTrait, TypeMacro,
         TypeParen, TypePath, TypePtr, TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
     },
 };

--- a/tools/codegen/src/ast_struct.rs
+++ b/tools/codegen/src/ast_struct.rs
@@ -92,12 +92,17 @@ fn field_attrs(field: &str, ty: &Type, defs: &Definitions) -> TokenStream {
                 assert_eq!(field, "vis");
                 return quote!(#[serde(default, skip_serializing_if = "Visibility::is_inherited")]);
             }
-            "StaticMutability" | "FieldMutability" => {
+            "StaticMutability" => {
                 assert_eq!(field, "mutability");
-                let is_none = format!("{ty}::is_none");
                 return quote! {
                     #[serde(rename = "mut")]
-                    #[serde(default, skip_serializing_if = #is_none)]
+                    #[serde(default, skip_serializing_if = "StaticMutability::is_none")]
+                };
+            }
+            "Safety" => {
+                assert_eq!(field, "safety");
+                return quote! {
+                    #[serde(default, skip_serializing_if = "Safety::is_default")]
                 };
             }
             "Generics" => {
@@ -107,10 +112,6 @@ fn field_attrs(field: &str, ty: &Type, defs: &Definitions) -> TokenStream {
             "PathArguments" => {
                 assert_eq!(field, "arguments");
                 return quote!(#[serde(default, skip_serializing_if = "PathArguments::is_none")]);
-            }
-            "TraitBoundModifier" => {
-                assert_eq!(field, "modifier");
-                return quote!(#[serde(default, skip_serializing_if = "TraitBoundModifier::is_none")]);
             }
             "ReturnType" => {
                 assert_eq!(field, "output");
@@ -134,7 +135,7 @@ fn skip_serializing_if(ident: &str, field: &str, ty: &Type) -> Option<String> {
     match (ident, field) {
         (_, "attrs")
         | ("Attribute", "tokens")
-        | ("TypeParam" | "LifetimeDef" | "TraitItemType", "bounds")
+        | ("TypeParam" | "LifetimeParam" | "TraitItemType", "bounds")
         | ("ItemTrait", "supertraits") => Some(format!("{}::is_empty", outer_ty(ty))),
         _ => None,
     }

--- a/tools/codegen/src/convert.rs
+++ b/tools/codegen/src/convert.rs
@@ -10,11 +10,44 @@ use crate::{traverse, workspace_root};
 const CONVERT_SRC: &str = "src/gen/convert.rs";
 
 // optimize
-pub(crate) const IGNORED_TYPES: &[&str] =
-    &["Arm", "ExprMatch", "Generics", "ItemStruct", "Receiver", "ReturnType", "TraitItemFn"];
+pub(crate) const IGNORED_TYPES: &[&str] = &[
+    "Arm",
+    "ExprMatch",
+    "File",
+    "Generics",
+    "ItemImpl",
+    "ItemStruct",
+    "Receiver",
+    "ReturnType",
+    "TraitItemFn",
+];
 
-pub(crate) const EMPTY_STRUCTS: &[&str] =
-    &["TypeInfer", "TypeNever", "UseGlob", "VisCrate", "VisPublic"];
+pub(crate) const EMPTY_STRUCTS: &[&str] = &[
+    "BlockModifiers",
+    "ClosureModifiers",
+    "FieldModifiers",
+    "LocalModifiers",
+    "TraitBoundModifiers",
+    "TypeInfer",
+    "TypeNever",
+    "UseGlob",
+    "VisCrate",
+    "VisPublic",
+];
+
+// EMPTY_STRUCTS that are also #[non_exhaustive]: can't use struct literal, must use Default::default()
+const NON_EXHAUSTIVE_EMPTY_STRUCTS: &[&str] = &[
+    "BlockModifiers",
+    "ClosureModifiers",
+    "FieldModifiers",
+    "LocalModifiers",
+    "TraitBoundModifiers",
+];
+
+// Non-empty structs marked #[non_exhaustive] in syn: can't use struct literal at all,
+// must use Default::default() + field mutation
+const NON_EXHAUSTIVE_STRUCTS: &[&str] =
+    &["ConstModifiers", "FnModifiers", "ImplModifiers", "TraitModifiers", "TypeModifiers"];
 
 fn visit(ty: &Type, var: &TokenStream, defs: &Definitions) -> (Option<TokenStream>, TokenStream) {
     match ty {
@@ -91,8 +124,12 @@ fn visit(ty: &Type, var: &TokenStream, defs: &Definitions) -> (Option<TokenStrea
             let ident = format_ident!("{}", node.ident);
             if let Data::Struct(fields) = &node.data {
                 let from = None;
-                let fields = fields.keys().map(|f| format_ident!("{f}"));
-                let into = quote!(syn::#ident { #(#fields: default(),)* });
+                let into = if NON_EXHAUSTIVE_EMPTY_STRUCTS.contains(&&**t) {
+                    quote!(<syn::#ident>::default())
+                } else {
+                    let fields = fields.keys().map(|f| format_ident!("{f}"));
+                    quote!(syn::#ident { #(#fields: default(),)* })
+                };
                 return (from, into);
             }
             unreachable!()
@@ -200,6 +237,7 @@ fn node(impls: &mut TokenStream, node: &Node, defs: &Definitions) {
         Data::Struct(fields) => {
             let mut from_fields = TokenStream::new();
             let mut into_fields = TokenStream::new();
+            let mut into_assignments = TokenStream::new();
 
             for (field, ty) in fields {
                 let field = format_ident!("{field}");
@@ -211,6 +249,7 @@ fn node(impls: &mut TokenStream, node: &Node, defs: &Definitions) {
                     from_fields.extend(quote!(#field: #from,));
                 }
                 into_fields.extend(quote!(#field: #into,));
+                into_assignments.extend(quote!(_r.#field = #into;));
             }
 
             assert!(!fields.is_empty(), "fields.is_empty: {ident}");
@@ -219,9 +258,18 @@ fn node(impls: &mut TokenStream, node: &Node, defs: &Definitions) {
             from_impl.extend(quote! {
                 Self { #from_fields }
             });
-            into_impl.extend(quote! {
-                Self { #into_fields }
-            });
+            if NON_EXHAUSTIVE_STRUCTS.contains(&&*node.ident) {
+                // #[non_exhaustive] structs: can't use struct literal at all, must mutate fields
+                into_impl.extend(quote! {
+                    let mut _r = <syn::#ident>::default();
+                    #into_assignments
+                    _r
+                });
+            } else {
+                into_impl.extend(quote! {
+                    Self { #into_fields }
+                });
+            }
         }
         Data::Private => return,
     }

--- a/tools/codegen/syn.json
+++ b/tools/codegen/syn.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.15",
+  "version": "3.0.3",
   "types": [
     {
       "ident": "Abi",
@@ -65,20 +65,6 @@
         },
         "pat": {
           "syn": "Pat"
-        },
-        "guard": {
-          "option": {
-            "tuple": [
-              {
-                "token": "If"
-              },
-              {
-                "box": {
-                  "syn": "Expr"
-                }
-              }
-            ]
-          }
         },
         "fat_arrow_token": {
           "token": "FatArrow"
@@ -182,73 +168,6 @@
         },
         "meta": {
           "syn": "Meta"
-        }
-      }
-    },
-    {
-      "ident": "BareFnArg",
-      "features": {
-        "any": [
-          "derive",
-          "full"
-        ]
-      },
-      "fields": {
-        "attrs": {
-          "vec": {
-            "syn": "Attribute"
-          }
-        },
-        "name": {
-          "option": {
-            "tuple": [
-              {
-                "proc_macro2": "Ident"
-              },
-              {
-                "token": "Colon"
-              }
-            ]
-          }
-        },
-        "ty": {
-          "syn": "Type"
-        }
-      }
-    },
-    {
-      "ident": "BareVariadic",
-      "features": {
-        "any": [
-          "derive",
-          "full"
-        ]
-      },
-      "fields": {
-        "attrs": {
-          "vec": {
-            "syn": "Attribute"
-          }
-        },
-        "name": {
-          "option": {
-            "tuple": [
-              {
-                "proc_macro2": "Ident"
-              },
-              {
-                "token": "Colon"
-              }
-            ]
-          }
-        },
-        "dots": {
-          "token": "DotDotDot"
-        },
-        "comma": {
-          "option": {
-            "token": "Comma"
-          }
         }
       }
     },
@@ -423,6 +342,15 @@
       }
     },
     {
+      "ident": "BlockModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {}
+    },
+    {
       "ident": "BoundLifetimes",
       "features": {
         "any": [
@@ -447,6 +375,30 @@
         },
         "gt_token": {
           "token": "Gt"
+        }
+      }
+    },
+    {
+      "ident": "ClosureModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {}
+    },
+    {
+      "ident": "ConstModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "defaultness": {
+          "option": {
+            "token": "Default"
+          }
         }
       }
     },
@@ -476,14 +428,16 @@
         "ty": {
           "syn": "Type"
         },
-        "eq_token": {
-          "option": {
-            "token": "Eq"
-          }
-        },
         "default": {
           "option": {
-            "syn": "Expr"
+            "tuple": [
+              {
+                "token": "Eq"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
           }
         }
       }
@@ -775,6 +729,11 @@
             "syn": "ExprRange"
           }
         ],
+        "RawAddr": [
+          {
+            "syn": "ExprRawAddr"
+          }
+        ],
         "Reference": [
           {
             "syn": "ExprReference"
@@ -907,6 +866,9 @@
         },
         "async_token": {
           "token": "Async"
+        },
+        "modifiers": {
+          "syn": "BlockModifiers"
         },
         "capture": {
           "option": {
@@ -1105,14 +1067,12 @@
             "syn": "BoundLifetimes"
           }
         },
+        "modifiers": {
+          "syn": "ClosureModifiers"
+        },
         "constness": {
           "option": {
             "token": "Const"
-          }
-        },
-        "movability": {
-          "option": {
-            "token": "Static"
           }
         },
         "asyncness": {
@@ -1125,7 +1085,7 @@
             "token": "Move"
           }
         },
-        "or1_token": {
+        "inputs_begin": {
           "token": "Or"
         },
         "inputs": {
@@ -1136,7 +1096,7 @@
             "punct": "Comma"
           }
         },
-        "or2_token": {
+        "inputs_end": {
           "token": "Or"
         },
         "output": {
@@ -1164,6 +1124,9 @@
         },
         "const_token": {
           "token": "Const"
+        },
+        "modifiers": {
+          "syn": "BlockModifiers"
         },
         "block": {
           "syn": "Block"
@@ -1619,6 +1582,35 @@
       }
     },
     {
+      "ident": "ExprRawAddr",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "and_token": {
+          "token": "And"
+        },
+        "raw": {
+          "token": "Raw"
+        },
+        "mutability": {
+          "syn": "PointerMutability"
+        },
+        "expr": {
+          "box": {
+            "syn": "Expr"
+          }
+        }
+      }
+    },
+    {
       "ident": "ExprReference",
       "features": {
         "any": [
@@ -1787,6 +1779,9 @@
         "try_token": {
           "token": "Try"
         },
+        "modifiers": {
+          "syn": "BlockModifiers"
+        },
         "block": {
           "syn": "Block"
         }
@@ -1936,8 +1931,8 @@
         "vis": {
           "syn": "Visibility"
         },
-        "mutability": {
-          "syn": "FieldMutability"
+        "modifiers": {
+          "syn": "FieldModifiers"
         },
         "ident": {
           "option": {
@@ -1951,21 +1946,30 @@
         },
         "ty": {
           "syn": "Type"
+        },
+        "default": {
+          "option": {
+            "tuple": [
+              {
+                "token": "Eq"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
+          }
         }
       }
     },
     {
-      "ident": "FieldMutability",
+      "ident": "FieldModifiers",
       "features": {
         "any": [
           "derive",
           "full"
         ]
       },
-      "variants": {
-        "None": []
-      },
-      "exhaustive": false
+      "fields": {}
     },
     {
       "ident": "FieldPat",
@@ -2133,6 +2137,57 @@
       }
     },
     {
+      "ident": "FnModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "defaultness": {
+          "option": {
+            "token": "Default"
+          }
+        }
+      }
+    },
+    {
+      "ident": "FnPtrVariadic",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "name": {
+          "option": {
+            "tuple": [
+              {
+                "proc_macro2": "Ident"
+              },
+              {
+                "token": "Colon"
+              }
+            ]
+          }
+        },
+        "dots": {
+          "token": "DotDotDot"
+        },
+        "comma": {
+          "option": {
+            "token": "Comma"
+          }
+        }
+      }
+    },
+    {
       "ident": "ForeignItem",
       "features": {
         "any": [
@@ -2184,6 +2239,9 @@
         "vis": {
           "syn": "Visibility"
         },
+        "modifiers": {
+          "syn": "FnModifiers"
+        },
         "sig": {
           "syn": "Signature"
         },
@@ -2231,6 +2289,9 @@
         "vis": {
           "syn": "Visibility"
         },
+        "safety": {
+          "syn": "Safety"
+        },
         "static_token": {
           "token": "Static"
         },
@@ -2268,6 +2329,9 @@
         },
         "vis": {
           "syn": "Visibility"
+        },
+        "modifiers": {
+          "syn": "TypeModifiers"
         },
         "type_token": {
           "token": "Type"
@@ -2437,10 +2501,8 @@
         "vis": {
           "syn": "Visibility"
         },
-        "defaultness": {
-          "option": {
-            "token": "Default"
-          }
+        "modifiers": {
+          "syn": "ConstModifiers"
         },
         "const_token": {
           "token": "Const"
@@ -2484,10 +2546,8 @@
         "vis": {
           "syn": "Visibility"
         },
-        "defaultness": {
-          "option": {
-            "token": "Default"
-          }
+        "modifiers": {
+          "syn": "FnModifiers"
         },
         "sig": {
           "syn": "Signature"
@@ -2536,10 +2596,8 @@
         "vis": {
           "syn": "Visibility"
         },
-        "defaultness": {
-          "option": {
-            "token": "Default"
-          }
+        "modifiers": {
+          "syn": "TypeModifiers"
         },
         "type_token": {
           "token": "Type"
@@ -2562,14 +2620,24 @@
       }
     },
     {
-      "ident": "ImplRestriction",
+      "ident": "ImplModifiers",
       "features": {
         "any": [
           "full"
         ]
       },
-      "variants": {},
-      "exhaustive": false
+      "fields": {
+        "defaultness": {
+          "option": {
+            "token": "Default"
+          }
+        },
+        "polarity": {
+          "option": {
+            "token": "Not"
+          }
+        }
+      }
     },
     {
       "ident": "Index",
@@ -2694,6 +2762,9 @@
         },
         "vis": {
           "syn": "Visibility"
+        },
+        "modifiers": {
+          "syn": "ConstModifiers"
         },
         "const_token": {
           "token": "Const"
@@ -2821,6 +2892,9 @@
         "vis": {
           "syn": "Visibility"
         },
+        "modifiers": {
+          "syn": "FnModifiers"
+        },
         "sig": {
           "syn": "Signature"
         },
@@ -2875,10 +2949,8 @@
             "syn": "Attribute"
           }
         },
-        "defaultness": {
-          "option": {
-            "token": "Default"
-          }
+        "modifiers": {
+          "syn": "ImplModifiers"
         },
         "unsafety": {
           "option": {
@@ -2894,11 +2966,6 @@
         "trait_": {
           "option": {
             "tuple": [
-              {
-                "option": {
-                  "token": "Not"
-                }
-              },
               {
                 "syn": "Path"
               },
@@ -3096,19 +3163,12 @@
         "vis": {
           "syn": "Visibility"
         },
+        "modifiers": {
+          "syn": "TraitModifiers"
+        },
         "unsafety": {
           "option": {
             "token": "Unsafe"
-          }
-        },
-        "auto_token": {
-          "option": {
-            "token": "Auto"
-          }
-        },
-        "restriction": {
-          "option": {
-            "syn": "ImplRestriction"
           }
         },
         "trait_token": {
@@ -3200,6 +3260,9 @@
         "vis": {
           "syn": "Visibility"
         },
+        "modifiers": {
+          "syn": "TypeModifiers"
+        },
         "type_token": {
           "token": "Type"
         },
@@ -3219,6 +3282,9 @@
         },
         "semi_token": {
           "token": "Semi"
+        },
+        "where_clause_placement": {
+          "syn": "WhereClausePlacement"
         }
       }
     },
@@ -3461,6 +3527,9 @@
         "let_token": {
           "token": "Let"
         },
+        "modifiers": {
+          "syn": "LocalModifiers"
+        },
         "pat": {
           "syn": "Pat"
         },
@@ -3505,6 +3574,15 @@
           }
         }
       }
+    },
+    {
+      "ident": "LocalModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {}
     },
     {
       "ident": "Macro",
@@ -3643,6 +3721,37 @@
       }
     },
     {
+      "ident": "NamedArg",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "name": {
+          "option": {
+            "tuple": [
+              {
+                "proc_macro2": "Ident"
+              },
+              {
+                "token": "Colon"
+              }
+            ]
+          }
+        },
+        "ty": {
+          "syn": "Type"
+        }
+      }
+    },
+    {
       "ident": "ParenthesizedGenericArguments",
       "features": {
         "any": [
@@ -3657,7 +3766,7 @@
         "inputs": {
           "punctuated": {
             "element": {
-              "syn": "Type"
+              "syn": "NamedArg"
             },
             "punct": "Comma"
           }
@@ -4137,6 +4246,27 @@
       }
     },
     {
+      "ident": "PointerMutability",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "variants": {
+        "Const": [
+          {
+            "token": "Const"
+          }
+        ],
+        "Mut": [
+          {
+            "token": "Mut"
+          }
+        ]
+      }
+    },
+    {
       "ident": "PredicateLifetime",
       "features": {
         "any": [
@@ -4145,6 +4275,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "lifetime": {
           "syn": "Lifetime"
         },
@@ -4170,6 +4305,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "lifetimes": {
           "option": {
             "syn": "BoundLifetimes"
@@ -4311,6 +4451,28 @@
       }
     },
     {
+      "ident": "Safety",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "variants": {
+        "Safe": [
+          {
+            "token": "Safe"
+          }
+        ],
+        "Unsafe": [
+          {
+            "token": "Unsafe"
+          }
+        ],
+        "Default": []
+      },
+      "exhaustive": true
+    },
+    {
       "ident": "Signature",
       "features": {
         "any": [
@@ -4328,10 +4490,8 @@
             "token": "Async"
           }
         },
-        "unsafety": {
-          "option": {
-            "token": "Unsafe"
-          }
+        "safety": {
+          "syn": "Safety"
         },
         "abi": {
           "option": {
@@ -4457,12 +4617,17 @@
             "group": "Paren"
           }
         },
-        "modifier": {
-          "syn": "TraitBoundModifier"
-        },
         "lifetimes": {
           "option": {
             "syn": "BoundLifetimes"
+          }
+        },
+        "modifiers": {
+          "syn": "TraitBoundModifiers"
+        },
+        "maybe": {
+          "option": {
+            "token": "Question"
           }
         },
         "path": {
@@ -4471,21 +4636,14 @@
       }
     },
     {
-      "ident": "TraitBoundModifier",
+      "ident": "TraitBoundModifiers",
       "features": {
         "any": [
           "derive",
           "full"
         ]
       },
-      "variants": {
-        "None": [],
-        "Maybe": [
-          {
-            "token": "Question"
-          }
-        ]
-      }
+      "fields": {}
     },
     {
       "ident": "TraitItem",
@@ -4535,6 +4693,9 @@
           "vec": {
             "syn": "Attribute"
           }
+        },
+        "modifiers": {
+          "syn": "ConstModifiers"
         },
         "const_token": {
           "token": "Const"
@@ -4632,6 +4793,9 @@
             "syn": "Attribute"
           }
         },
+        "modifiers": {
+          "syn": "TypeModifiers"
+        },
         "type_token": {
           "token": "Type"
         },
@@ -4672,6 +4836,21 @@
       }
     },
     {
+      "ident": "TraitModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "auto_token": {
+          "option": {
+            "token": "Auto"
+          }
+        }
+      }
+    },
+    {
       "ident": "Type",
       "features": {
         "any": [
@@ -4685,9 +4864,9 @@
             "syn": "TypeArray"
           }
         ],
-        "BareFn": [
+        "FnPtr": [
           {
-            "syn": "TypeBareFn"
+            "syn": "TypeFnPtr"
           }
         ],
         "Group": [
@@ -4767,6 +4946,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "bracket_token": {
           "group": "Bracket"
         },
@@ -4784,7 +4968,7 @@
       }
     },
     {
-      "ident": "TypeBareFn",
+      "ident": "TypeFnPtr",
       "features": {
         "any": [
           "derive",
@@ -4792,6 +4976,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "lifetimes": {
           "option": {
             "syn": "BoundLifetimes"
@@ -4816,14 +5005,14 @@
         "inputs": {
           "punctuated": {
             "element": {
-              "syn": "BareFnArg"
+              "syn": "NamedArg"
             },
             "punct": "Comma"
           }
         },
         "variadic": {
           "option": {
-            "syn": "BareVariadic"
+            "syn": "FnPtrVariadic"
           }
         },
         "output": {
@@ -4840,6 +5029,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "group_token": {
           "group": "Group"
         },
@@ -4859,6 +5053,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "impl_token": {
           "token": "Impl"
         },
@@ -4881,6 +5080,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "underscore_token": {
           "token": "Underscore"
         }
@@ -4895,8 +5099,28 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "mac": {
           "syn": "Macro"
+        }
+      }
+    },
+    {
+      "ident": "TypeModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "defaultness": {
+          "option": {
+            "token": "Default"
+          }
         }
       }
     },
@@ -4909,6 +5133,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "bang_token": {
           "token": "Not"
         }
@@ -4944,14 +5173,16 @@
             "punct": "Plus"
           }
         },
-        "eq_token": {
-          "option": {
-            "token": "Eq"
-          }
-        },
         "default": {
           "option": {
-            "syn": "Type"
+            "tuple": [
+              {
+                "token": "Eq"
+              },
+              {
+                "syn": "Type"
+              }
+            ]
           }
         }
       }
@@ -4992,6 +5223,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "paren_token": {
           "group": "Paren"
         },
@@ -5011,6 +5247,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "qself": {
           "option": {
             "syn": "QSelf"
@@ -5030,18 +5271,16 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "star_token": {
           "token": "Star"
         },
-        "const_token": {
-          "option": {
-            "token": "Const"
-          }
-        },
         "mutability": {
-          "option": {
-            "token": "Mut"
-          }
+          "syn": "PointerMutability"
         },
         "elem": {
           "box": {
@@ -5059,6 +5298,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "and_token": {
           "token": "And"
         },
@@ -5088,6 +5332,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "bracket_token": {
           "group": "Bracket"
         },
@@ -5107,6 +5356,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "dyn_token": {
           "option": {
             "token": "Dyn"
@@ -5131,6 +5385,11 @@
         ]
       },
       "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
         "paren_token": {
           "group": "Paren"
         },
@@ -5436,6 +5695,19 @@
       }
     },
     {
+      "ident": "WhereClausePlacement",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "variants": {
+        "Early": [],
+        "Late": []
+      },
+      "exhaustive": true
+    },
+    {
       "ident": "WherePredicate",
       "features": {
         "any": [
@@ -5557,6 +5829,8 @@
     "Virtual": "virtual",
     "Where": "where",
     "While": "while",
-    "Yield": "yield"
+    "Yield": "yield",
+    "Raw": "raw",
+    "Safe": "safe"
   }
 }


### PR DESCRIPTION
Hi there,

Thanks for this great crate! :pray:

It has saved me a lot of time and effort, so I'd like to give back by upgrading it to `syn = "3"`.

This is my first contribution here, so please let me know if anything is improper or could be done differently. I'm happy to make adjustments based on your feedback.

Thanks in advance!